### PR TITLE
Update docker-compose.yaml

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,3 +1,4 @@
+version: '3'
 services:
   process-exporter:
     volumes:


### PR DESCRIPTION
Fixes:

```
vagrant@ubuntu-groovy:~/repos/simple-linux-monitoring-stack$ docker-compose up
ERROR: The Compose file './docker-compose.yaml' is invalid because:
Unsupported config option for services: 'process-exporter'
```